### PR TITLE
images/ci: add rst2man

### DIFF
--- a/images/archlinux-ci/Dockerfile
+++ b/images/archlinux-ci/Dockerfile
@@ -20,4 +20,5 @@ RUN pacman -Sy \
                 libsystemd \
                 meson \
                 ninja \
+                python-docutils \
                 valgrind

--- a/images/fedora-ci/Dockerfile
+++ b/images/fedora-ci/Dockerfile
@@ -34,6 +34,7 @@ RUN dnf -y --nodocs update \
                 ninja-build \
                 patch \
                 pkgconf \
+                python2-docutils \
                 sed \
                 sudo \
                 systemd-devel \


### PR DESCRIPTION
This is needed by dbus-broker to generate man pages.

Signed-off-by: Tom Gundersen <teg@jklm.no>